### PR TITLE
Page overflow styling fix 2.0

### DIFF
--- a/frontend/src/modules/GroupsModule.tsx
+++ b/frontend/src/modules/GroupsModule.tsx
@@ -16,7 +16,7 @@ export default function GroupsModule() {
     // Render for student
     if (userInfo?.role === "student") {
         return (
-            <div className="p-1 space-y-6">
+            <div className="p-1 space-y-6 h-full">
                 {/* Welcome Section */}
                 <div className="module rounded-2xl shadow-md p-4 flex items-center">
                     <div className="pl-8 flex-1">

--- a/frontend/src/modules/StudentCourseGroups.tsx
+++ b/frontend/src/modules/StudentCourseGroups.tsx
@@ -20,7 +20,7 @@ export function StudentCourseGroups(props: StudentCourseGroupsProps) {
         <h2 className="text-3xl mt-5 font-bold">
             Other Groups
         </h2>
-        <div className="m-5">
+        <div className="mx-5">
             
             {props.courseInfo.groups.map((g)=>(
                 <div>

--- a/frontend/src/pages/course/CoursePage.tsx
+++ b/frontend/src/pages/course/CoursePage.tsx
@@ -39,7 +39,7 @@ export default function CoursePage() {
                         </div>
                         <img src="/src/assets/books.png" alt="Welcome" className="pr-12 w-[250px] h-40 object-contain" />
                     </div>
-                    <div className="module mt-10 rounded-2xl shadow-md p-4 flex items-center">
+                    <div className="module mt-5 rounded-2xl shadow-md p-4 flex items-center">
                         <div className="pl-8 flex-1 text-white">
                             {userInfo?.role =="teacher" && <TeacherCourseGroups courseInfo={courseInfo} refreshGroups={refreshGroups}/>}
                             {userInfo?.role =="student" && <StudentCourseGroups courseInfo={courseInfo} />}

--- a/frontend/src/pages/home/courses/StudentCourses.tsx
+++ b/frontend/src/pages/home/courses/StudentCourses.tsx
@@ -55,12 +55,14 @@ export default function StudentCourses() {
           </p>
         </div>
       ) : (
-        <div className="flex flex-wrap gap-10 items-start">
+        <div className="flex flex-wrap gap-10 items-start ">
           {courses.map((course) => (
             <div className="" key={course.courseid}>
               <a
                 href={`/courses/${course.courseid}`}
-                className="block w-[200px] min-h-[150px] rounded-lg border-gray-200 bg-white p-6 shadow hover:bg-zinc-100 dark:border-gray-700"
+                className="block w-[200px] min-h-[150px] rounded-lg border-gray-200 bg-white p-6 shadow hover:bg-zinc-100 dark:border-gray-700
+                duration-300 transform outline-none hover:scale-105 hover:shadow-lg
+                "
               >
                 <div className="class-card-header">
                   <span className="icon">📚</span>

--- a/frontend/src/pages/home/courses/TeacherCourses.tsx
+++ b/frontend/src/pages/home/courses/TeacherCourses.tsx
@@ -53,7 +53,8 @@ export default function TeacherCourses() {
             <div className="" key={course.courseid}>
               <a
                 href={`/courses/${course.courseid}`}
-                className="block w-[200px] min-h-[150px] rounded-lg border-gray-200 bg-white p-6 shadow hover:bg-zinc-100 dark:border-gray-700"
+                className="block w-[200px] min-h-[150px] rounded-lg border-gray-200 bg-white p-6 shadow hover:bg-zinc-100 dark:border-gray-700
+                duration-300 transform outline-none hover:scale-105 hover:shadow-lg"
               >
                 <div className="class-card-header">
                   <span className="icon">📚</span>

--- a/frontend/src/pages/main/MainPage.tsx
+++ b/frontend/src/pages/main/MainPage.tsx
@@ -13,8 +13,8 @@ const Main: React.FC = () => {
   return (
     <UserInfoContext.Provider value={userInfo}>
         <SidebarPageTemplate hidden={!displayContent}>
-          <div className="bg-[#9B394B] p-3">
-            <div className='bg-[#FCF4F5] rounded-2xl p-6'>
+          <div className="bg-[#9B394B] p-3 h-full">
+            <div className='bg-[#FCF4F5] h-full rounded-2xl p-6'>
               <GroupsModule />
             </div>
           </div>


### PR DESCRIPTION
This PR fixes the overflow and filling issue we had with the home and course modules. The modules should now fill the parent container. Extra hover effect styling was copied from the sidebar and applied to the My classes elements.