### PR TITLE
Allow summary page to extend fully with the content in the summary page

### DIFF
--- a/frontend/src/pages/course/CourseSummaryPage.tsx
+++ b/frontend/src/pages/course/CourseSummaryPage.tsx
@@ -40,7 +40,7 @@ export function CourseSummaryPage() {
     <UserInfoContext.Provider value={userInfo}>
       <SidebarPageTemplate hidden={!displayContent}>
         <div className="bg-[#9B394B] p-3 min-h-full">
-          <div className="bg-[#FCF4F5] rounded-2xl p-6 h-full">
+          <div className="bg-[#FCF4F5] rounded-2xl p-6 min-h-full">
             <div className="flex flex-col module rounded-2xl shadow-md p-4">
               <h1 className="text-2xl font-bold text-white">
                 Summary View of {courseCode}

--- a/frontend/src/templates/SidebarPageTemplate.tsx
+++ b/frontend/src/templates/SidebarPageTemplate.tsx
@@ -9,7 +9,7 @@ export default function SidebarPageTemplate({ hidden, children }: SidebarPageTem
     return !hidden && (
         <div className='grid grid-cols-[235px,_1fr] text-stone-950 bg-[#9B394B] h-[100vh] box-border'>
             <Sidebar />
-            <div className='bg-white rounded-lg shadow overflow-y-scroll'>
+            <div className='bg-white rounded-lg shadow overflow-y-scroll min-h-full'>
                 {children}
             </div>
         </div>


### PR DESCRIPTION
fixed the content wrapper

<img width="1206" alt="image" src="https://github.com/user-attachments/assets/15f2f96f-083e-4ad1-942f-07f0d6556465">
