### PR TITLE
Add Pages and Reroute for User Profile

### DIFF
--- a/frontend/src/AppRoutes.tsx
+++ b/frontend/src/AppRoutes.tsx
@@ -9,6 +9,7 @@ import RatePage from "./pages/RatePage";
 import { CourseDetailsPage } from "./pages/course/CourseDetailsPage";
 import { CourseSummaryPage } from "./pages/course/CourseSummaryPage";
 import CoursePage from "./pages/course/CoursePage";
+import { UserProfilePage } from "./pages/userProfile/UserProfilePage";
 
 export const AppRoutes = createBrowserRouter([
   {
@@ -50,5 +51,9 @@ export const AppRoutes = createBrowserRouter([
   {
     path: "/ratings/:groupid/:email/new",
     element: <RatePage/>
+  },
+  {
+    path: "/profile/:email",
+    element: <UserProfilePage/>
   }
 ]);

--- a/frontend/src/modules/AccountToggle.tsx
+++ b/frontend/src/modules/AccountToggle.tsx
@@ -15,21 +15,23 @@ export const AccountToggle = () => {
 
   return (
     <div className='mb-4 mt-2 pd-4 border-stone-300'>
-      <button className='flex account py-5 hover:bg-rose-900 p-3 rounded-lg transition-colors relative gap-2 w-full items-center mb-2'>
-        <img
-          src={profileIconUrl}
-          alt="avatar"
-          className='size-8 rounded shrink-0 bg-indigo-600'
-        />
-        <div className='text-start'>
-          <div className="text-start text-white">
-            <span className="text-sm font-extrabold block ">
-              {userInfo?.firstname} {userInfo?.lastname}
-            </span>
-            <span className="text-xs block">{capitalizeRole(userInfo?.role)}</span>
+      <a href={`/profile/${userInfo?.email}`} > 
+        <button className='flex account py-5 hover:bg-rose-900 p-3 rounded-lg transition-colors relative gap-2 w-full items-center mb-2'>
+          <img
+            src={profileIconUrl}
+            alt="avatar"
+            className='size-8 rounded shrink-0 bg-indigo-600'
+          />
+          <div className='text-start'>
+            <div className="text-start text-white">
+              <span className="text-sm font-extrabold block ">
+                {userInfo?.firstname} {userInfo?.lastname}
+              </span>
+              <span className="text-xs block">{capitalizeRole(userInfo?.role)}</span>
+            </div>
           </div>
-        </div>
-      </button>
+        </button>
+      </a>
     </div>
   );
 };

--- a/frontend/src/pages/userProfile/UserProfilePage.tsx
+++ b/frontend/src/pages/userProfile/UserProfilePage.tsx
@@ -1,0 +1,19 @@
+import { useParams } from "react-router-dom";
+import UserInfoContext from "../../contexts/userinfo";
+import { useRequireAuthenticated } from "../../hooks/auth";
+import { useUserInfo } from "../../hooks/useUserInfo";
+import SidebarPageTemplate from "../../templates/SidebarPageTemplate";
+
+export function UserProfilePage() {
+  const userInfo = useUserInfo();
+  const displayContent = useRequireAuthenticated();
+  const { email } = useParams();
+  return (
+    <UserInfoContext.Provider value={userInfo}>
+      <SidebarPageTemplate hidden={!displayContent}>
+        {/* page content here */}
+        {email}
+      </SidebarPageTemplate>
+    </UserInfoContext.Provider>
+  );
+}


### PR DESCRIPTION
Add Pages and Reroutes for UserProfile based on their email.
The path used follows the format of `/profile/:email`

![image](https://github.com/user-attachments/assets/27ccbb37-c7eb-4724-a021-b134f23f0a05)
